### PR TITLE
limited validation to microsecond due to hardware inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # Timer
 Provides stopwatch type controls for multiple streams
+

--- a/src/FTTimer.cpp
+++ b/src/FTTimer.cpp
@@ -26,9 +26,9 @@ namespace FTTimer
     std::chrono::system_clock::now();
 
     auto dur = now.time_since_epoch();
-    auto tics = std::chrono::duration_cast<std::chrono::microseconds>(dur).count();
+    auto tics = std::chrono::duration_cast<std::chrono::nanoseconds>(dur).count();
 
-    double usecs = static_cast<double>(tics)/ 1e6;
+    double usecs = static_cast<double>(tics)/ 1e9;
 
     return usecs;
   }
@@ -52,10 +52,8 @@ namespace FTTimer
   std::string convertTimestampToString( double timestamp ) {
     using namespace std::chrono;
 
-    auto sec_dur  = seconds { static_cast<uint64_t>(timestamp) };
-    auto usec_dur = microseconds{static_cast<uint64_t>(timestamp * 1e6)};
-//    auto nsec_dur = duration_cast<nanoseconds>( timestamp *1e9);
-//
+    auto usec_dur = nanoseconds{static_cast<uint64_t>(timestamp * 1e9)};
+
     time_point<system_clock> tp = time_point<system_clock>(nanoseconds(usec_dur));
    
     std::stringstream ss;

--- a/src/FTTimer.hpp
+++ b/src/FTTimer.hpp
@@ -3,6 +3,10 @@
  * 
  * This class is used as a common wrapper to ensure a consistent way of
  * accessing system across multiple platforms and software stacks. 
+ * 
+ * While this software attempts toe track resolution to the nanoseconds,
+ * hardware limitations can apply, so unit testing is only able to validate
+ * microsecond-scale clock resolutions.
  */
 
 namespace FTTimer


### PR DESCRIPTION
There was a random error based on processor load when comparing clock times, likely due to rounding. At this point, this library can only guarantee microsecond scale accuracy.